### PR TITLE
Fix chromedriver loading

### DIFF
--- a/netflix_household_update.py
+++ b/netflix_household_update.py
@@ -6,7 +6,6 @@ import configparser
 from selenium import webdriver
 from selenium.webdriver import Keys
 from selenium.webdriver.common.by import By
-from chromedriver_py import binary_path
 
 # Constants
 # Used as search criteria for netflix mail and button to click. Could be changed by Netflix in the future
@@ -41,10 +40,13 @@ class NetflixLocationUpdate:
         imap_password = self._config.get('EMAIL', 'Password')
 
         # Chromedriver config
-        use_chromedriver_py = self._config.getboolean('CHROMEDRIVER', 'UseChromedriverPy', fallback=True)
-        chromedriver_path = binary_path
-        if use_chromedriver_py is False:
+        use_chromedriver_py = self._config.getboolean('CHROMEDRIVER', 'UseChromedriverPy',>
+        if use_chromedriver_py:
+            from chromedriver_py import binary_path
+            chromedriver_path = binary_path
+        else:
             chromedriver_path = self._config.get('CHROMEDRIVER', 'ExecutablePath')
+
 
         # Logging config
         logging.basicConfig(filename='status.log', encoding='utf8', level=logging.INFO,


### PR DESCRIPTION
changed logic of chromedriver loading to respect the config.ini and not fail when loading the chromedriver_py package

Currently on my raspberry pi, the script will fail due to:
```
python ./netflix_household_update.py 
Traceback (most recent call last):
  File "/home/pi/dev/netflix-household-update/./netflix_household_update.py", line 9, in <module>
    from chromedriver_py import binary_path
  File "/home/pi/dev/netflix-household-update/.venv/lib/python3.9/site-packages/chromedriver_py/__init__.py", line 49, in <module>
    binary_path = _get_filename()
  File "/home/pi/dev/netflix-household-update/.venv/lib/python3.9/site-packages/chromedriver_py/__init__.py", line 32, in _get_filename
    raise Exception("Google doesn't compile chromedriver versions for Linux ARM. Sorry!")
Exception: Google doesn't compile chromedriver versions for Linux ARM. Sorry!
```

This is because chromedriver_py throws an exception while  being loaded. This leads to the config.ini to not taking effect when selecting a manual chromedriver.
